### PR TITLE
Swagger (Springdoc openAPI) 설정 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 	//implementation 'io.springfox:springfox-swagger-ui:2.9.2'
 
 	// springdoc OpenAPI
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
 	// 임시
 //	runtimeOnly( 'com.h2database:h2')

--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,12 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	// Swagger
-	implementation 'io.springfox:springfox-swagger2:2.9.2'
-	implementation 'io.springfox:springfox-swagger-ui:2.9.2'
+	// Swagger - 야는 옛날거라 일단 주석처리리
+	//implementation 'io.springfox:springfox-swagger2:2.9.2'
+	//implementation 'io.springfox:springfox-swagger-ui:2.9.2'
+
+	// springdoc OpenAPI
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
 	// 임시
 //	runtimeOnly( 'com.h2database:h2')

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// Swagger
+	implementation 'io.springfox:springfox-swagger2:2.9.2'
+	implementation 'io.springfox:springfox-swagger-ui:2.9.2'
+
 	// 임시
 //	runtimeOnly( 'com.h2database:h2')
 

--- a/src/main/java/com/skku/sucpi/SwaggerConfig.java
+++ b/src/main/java/com/skku/sucpi/SwaggerConfig.java
@@ -1,0 +1,28 @@
+package com.skku.sucpi;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+ 
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    
+ 
+    private Info apiInfo() {
+        return new Info()
+                .title("SUCPI API 명세서")
+                .description("SUCPI 프로젝트의 API 설명 문서입니다")
+                .version("1.0.0");
+    }
+}
+

--- a/src/main/java/com/skku/sucpi/controller/testController/TestController.java
+++ b/src/main/java/com/skku/sucpi/controller/testController/TestController.java
@@ -1,14 +1,22 @@
 package com.skku.sucpi.controller.testController;
 
-import com.skku.sucpi.dto.test.TestRequestDto;
-import com.skku.sucpi.dto.test.TestResponseDto;
-import com.skku.sucpi.service.TestService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.skku.sucpi.dto.test.TestRequestDto;
+import com.skku.sucpi.dto.test.TestResponseDto;
+import com.skku.sucpi.service.TestService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+
+@Tag(name = "예제 API", description = "Swagger 테스트용 API")
 @RequiredArgsConstructor
 @RestController
 public class TestController {
@@ -16,11 +24,23 @@ public class TestController {
     private final TestService testService;
 
     @GetMapping("/test")
+    @Operation(summary = "테스트 GET API", description = "간단한 테스트 api입니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공적으로 호출됨"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
     public String test() {
         return "Success";
     }
 
     @PostMapping("/test")
+    @Operation(summary = "테스트 POST API", description = "간단한 테스트 api입니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공적으로 호출됨"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
     public TestResponseDto save(@RequestBody TestRequestDto requestDto) {
         return testService.save(requestDto);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,6 +23,34 @@ SSO_HOST=${SKKU_SSO_HOST}
 SSO_PORT=${SKKU_SSO_PORT}
 JWT_SECRET_KEY=${SECRET_KEY}
 
+### Swagger springdoc ###
+springdoc:
+  packages-to-scan: com.skku.sucpi.controller
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /
+
+    # 각 API의 그룹 표시 순서
+    # path, query, body, response 순으로 출력
+    groups-order: DESC
+
+    # 태그 정렬 순서.
+    # alpha: 알파벳 순 정렬
+    tags-sorter: alpha
+
+    # 컨트롤러 정렬 순서.
+    # method는 delete - get - patch - post - put 순으로 정렬된다.
+    operations-sorter: method
+
+    # swagger-ui default url인 petstore html의 비활성화 설정
+    disable-swagger-default-url: true
+    
+    # swagger-ui에서 try 했을 때 request duration을 알려주는 설정
+    display-request-duration: true
+
+
+
 ### h2 ###
 #spring.jpa.show-sql=true
 #spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
Swagger (Springdoc openAPI) 설정 완료

test api에 예시로 적은 것처럼 작성하면 
http://localhost:8080/swagger-ui.html
에서 API 문서들을 확인할 수 있습니다.

tag 는 해당 controller 내의 api들을 묶어서 이름을 지을 수 있습니다. 이를 작성하지 않아도 url별로 묶여서 정리되긴 합니다.
POST API의 request body는 자동적으로 추적하여 swagger에 띄워지니 신경쓰지 않아도 됩니다. 다만, 추가로 설명이 필요한 경우 @parameter 태그를 활용한다면 좋습니다.

