### PR TITLE
[feat] sucpi#23 - student API 1차 세팅 완료, 본인 제출GET(제출상태별 확인가능, 페이징), 본인…

### DIFF
--- a/src/main/java/com/skku/sucpi/controller/student/StudentController.java
+++ b/src/main/java/com/skku/sucpi/controller/student/StudentController.java
@@ -1,0 +1,268 @@
+package com.skku.sucpi.controller.student;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.skku.sucpi.dto.ApiResponse;
+import com.skku.sucpi.dto.PaginationDto;
+import com.skku.sucpi.dto.submit.SubmitCreateRequestDto;
+import com.skku.sucpi.dto.submit.SubmitDto;
+import com.skku.sucpi.dto.user.StudentDto;
+import com.skku.sucpi.service.submit.SubmitService;
+import com.skku.sucpi.service.user.UserService;
+import com.skku.sucpi.util.JWTUtil;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Student API", description = "학생 전용 기능을 제공하는 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/student")
+public class StudentController {
+
+    private final UserService userService;
+    private final JWTUtil jwtUtil;
+    private final SubmitService submitService;
+
+    @Operation(
+        summary = "내 프로필 조회",
+        description = """
+        **사용법**  
+        GET /api/student/me  
+        **헤더**  
+        Authorization: Bearer {accessToken}  
+        
+        **응답 예시**  
+        ```json
+        {
+          "success": true,
+          "data": {
+            "id": 123,
+            "name": "홍길동",
+            "studentId": "2020310000",
+            "department": "소프트웨어학과",
+            "grade": 3,
+            "lq": 12.0,
+            "rq": 8.0,
+            "cq": 5.0,
+            "tLq": 15.2,
+            "tRq": 10.1,
+            "tCq": 7.3,
+            "totalScore": 25.0
+          },
+          "path": "/api/student/me"
+        }
+        ```
+        """
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프로필 조회 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = StudentDto.BasicInfo.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    @GetMapping("/me")
+    @PreAuthorize("hasRole('student')")
+    public ApiResponse<StudentDto.BasicInfo> getMyProfile(
+            HttpServletRequest request
+    ) {
+        String token = Optional.ofNullable(request.getHeader("Authorization"))
+            .filter(h -> h.startsWith("Bearer "))
+            .map(h -> h.substring(7))
+            .orElseThrow(() -> new IllegalArgumentException("인증 토큰이 없습니다."));
+        Long userId = jwtUtil.getUserId(token);
+
+        StudentDto.DetailInfo detail = userService.searchStudentInfo(userId);
+        return ApiResponse.success(detail.getBasicInfo(), request.getRequestURI());
+    }
+
+    @Operation(
+        summary = "내 제출 내역 조회",
+        description = """
+        **사용법**  
+        GET /api/student/submits?state={state}&page={page}&size={size}&sort=submitDate,desc  
+        **헤더**  
+        Authorization: Bearer {accessToken}  
+        
+        **쿼리 파라미터**  
+        - state (선택) : 0=미승인, 1=승인, 2=거부  
+        
+        **응답 예시**  
+        ```json
+        {
+          "success": true,
+          "data": {
+            "content": [
+              {
+                "id": 456,
+                "submitDate": "2025-05-12T14:00:00",
+                "state": 1,
+                "approvedDate": "2025-05-13T10:00:00",
+                "content": "과제 제출 내용",
+                "activityId": 10,
+                "activityClass": "education",
+                "activityName": "campus",
+                "activityDetail": "교내외 교육 활동",
+                "activityWeight": 0.2,
+                "activityDomain": 0,
+                "categoryId": 1,
+                "categoryName": "LQ",
+                "categoryRatio": 33.3
+              }
+            ],
+            "page": 0,
+            "size": 20,
+            "totalElements": 1,
+            "totalPage": 1
+          },
+          "path": "/api/student/submits"
+        }
+        ```
+        """
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "제출 내역 조회 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = PaginationDto.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    @GetMapping("/submits")
+    @PreAuthorize("hasRole('student')")
+    public ApiResponse<PaginationDto<SubmitDto.BasicInfo>> getMySubmits(
+        @Parameter(in = ParameterIn.QUERY, description = "제출 상태 (0:미승인, 1:승인, 2:거부)", example = "1")
+        @RequestParam(required = false) Integer state,
+
+        @Parameter(hidden = true)
+        @PageableDefault(size = 20, sort = "submitDate", direction = Sort.Direction.DESC)
+        Pageable pageable,
+
+        HttpServletRequest request
+    ) {
+        String token = Optional.ofNullable(request.getHeader("Authorization"))
+                .filter(h -> h.startsWith("Bearer "))
+                .map(h -> h.substring(7))
+                .orElseThrow(() -> new IllegalArgumentException("인증 토큰이 없습니다."));
+        Long userId = jwtUtil.getUserId(token);
+
+        PaginationDto<SubmitDto.BasicInfo> result =
+            submitService.getMySubmits(userId, state, pageable);
+
+        return ApiResponse.success(result, request.getRequestURI());
+    }
+
+    @Operation(
+        summary = "내 제출 내역 삭제",
+        description = """
+        **사용법**  
+        DELETE /api/student/submits/{id}  
+        **헤더**  
+        Authorization: Bearer {accessToken}  
+        """
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "승인된 제출 삭제 시도 또는 잘못된 요청")
+    })
+    @DeleteMapping("/submits/{id}")
+    @PreAuthorize("hasRole('student')")
+    public ApiResponse<Void> deleteMySubmit(
+        @Parameter(in = ParameterIn.PATH, description = "삭제할 제출 ID", example = "123")
+        @PathVariable("id") Long submitId,
+
+        HttpServletRequest request
+    ) {
+        String token = Optional.ofNullable(request.getHeader("Authorization"))
+                .filter(h -> h.startsWith("Bearer "))
+                .map(h -> h.substring(7))
+                .orElseThrow(() -> new IllegalArgumentException("인증 토큰이 없습니다."));
+        Long userId = jwtUtil.getUserId(token);
+
+        submitService.deleteSubmit(userId, submitId);
+        return ApiResponse.success(null, request.getRequestURI());
+    }
+
+    /**
+     * 학생 제출 API
+     * - activityId, content 는 필수, files 는 선택(다중 첨부 가능)
+     */
+    @Operation(summary = "학생 활동 제출 (multipart/form-data)",
+               description = "activityId, content 필수. files는 선택(다중 첨부 가능)")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode="200", description="제출 성공",
+                     content=@Content(mediaType="application/json")),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode="400", description="잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode="401", description="인증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode="403", description="권한 없음")
+    })
+    @PostMapping(value="/submits",
+                 consumes=MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasRole('student')")
+    public ApiResponse<SubmitDto.BasicInfo> createSubmit(
+        @Parameter(description="activityId, content JSON", required=true,
+                   in=ParameterIn.DEFAULT)
+        @RequestPart("requestDto") SubmitCreateRequestDto dto,
+
+        @Parameter(description="첨부파일들 (선택)", in=ParameterIn.DEFAULT,
+                   content=@Content(mediaType="application/octet-stream"))
+        @RequestPart(value="files", required=false)
+        List<MultipartFile> files,
+
+        HttpServletRequest request
+    ) throws Exception {
+        // JWT에서 userId 추출
+        String token = Optional.ofNullable(request.getHeader("Authorization"))
+            .filter(h -> h.startsWith("Bearer "))
+            .map(h -> h.substring(7))
+            .orElseThrow(() -> new IllegalArgumentException("인증 토큰이 없습니다."));
+        Long userId = jwtUtil.getUserId(token);
+
+        // 서비스 호출
+        SubmitDto.BasicInfo result = submitService.createSubmit(userId, dto, files);
+        return ApiResponse.success(result, request.getRequestURI());
+    }
+
+    @Operation(summary = "학생 활동 제출 (raw binary)",
+               description = "미리 생성된 submitId에 binary file 저장")
+    @PostMapping(value="/submits/{submitId}/file",
+                 consumes=MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    @PreAuthorize("hasRole('student')")
+    public void uploadBinaryFile(
+        @PathVariable Long submitId,
+        @RequestHeader("file-name") String name,
+        @RequestHeader("file-type") String type,
+        @RequestBody byte[] data
+    ) {
+        submitService.saveFileBinary(submitId, name, type, data);
+    }
+}

--- a/src/main/java/com/skku/sucpi/dto/submit/SubmitCreateRequestDto.java
+++ b/src/main/java/com/skku/sucpi/dto/submit/SubmitCreateRequestDto.java
@@ -1,0 +1,16 @@
+package com.skku.sucpi.dto.submit;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SubmitCreateRequestDto {
+    @NotNull(message = "activityId는 필수입니다.")
+    private Long activityId;
+
+    @NotBlank(message = "content는 필수입니다.")
+    private String content;
+}

--- a/src/main/java/com/skku/sucpi/entity/FileStorage.java
+++ b/src/main/java/com/skku/sucpi/entity/FileStorage.java
@@ -1,12 +1,23 @@
 package com.skku.sucpi.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @Entity(name = "file_storage")
 public class FileStorage {
 

--- a/src/main/java/com/skku/sucpi/entity/Submit.java
+++ b/src/main/java/com/skku/sucpi/entity/Submit.java
@@ -1,16 +1,31 @@
 package com.skku.sucpi.entity;
 
-import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.hibernate.annotations.UpdateTimestamp;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 @Getter
 @NoArgsConstructor(access =  AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)    // builder 전용 생성자
+@Builder                                              // Submit.builder()… .build() 사용 가능
 @Entity(name = "submit")
 public class Submit {
 

--- a/src/main/java/com/skku/sucpi/repository/SubmitRepositoryCustom.java
+++ b/src/main/java/com/skku/sucpi/repository/SubmitRepositoryCustom.java
@@ -1,14 +1,20 @@
 package com.skku.sucpi.repository;
 
+import org.springframework.data.domain.Pageable;
+
 import com.skku.sucpi.dto.PaginationDto;
 import com.skku.sucpi.dto.submit.SubmitDto;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 public interface SubmitRepositoryCustom {
     PaginationDto<SubmitDto.ListInfo> searchSubmitList(
             String userName,
             Integer state,
             Pageable pageable
+    );
+
+    PaginationDto<SubmitDto.BasicInfo> searchMySubmitsByUser(
+        Long userId,
+        Integer state,
+        Pageable pageable
     );
 }


### PR DESCRIPTION
* 혹시 push해서는 안되는 파일을 했다면 죄송합니다. 확인부탁드립니다 *


- auth에서의 수정사항은 테스트를 위해 따로 만든 1번 학생 로그인입니다. 
![image](https://github.com/user-attachments/assets/e72de46d-f74c-4f31-8073-3e83fc0643fa)
아이디 1번 학생으로 로그인하는 테스트용 로그인입니다.

해당 학생을 기준으로 테스트를 진행하였고, 문제없이 DB에 잘 적용됨을 확인하였습니다.

기본적인 swagger 설명도 되어있습니다.

(1차 api 세팅으로 이후에 프론트엔드의 상태에 맞게 response body 및 dto를 변경할 예정입니다)

추가 학생 api
![image](https://github.com/user-attachments/assets/3aa628f2-fe98-417d-b6df-4197f0574afd)
- 1. GET http://localhost:8080/api/student/me
    - 본인 정보 및 L,R,Cq 점수 확인

![image](https://github.com/user-attachments/assets/f97196eb-0831-49d0-9211-e9ff94a50074)
- 2. ex) GET http://localhost:8080/api/student/submits?state=0&page=0&size=10&sort=submitDate,desc
    - 본인의 제출 내역 상세 조회 (상태별, 페이지별로 조회, 날짜에 따른 정렬 가능)

![image](https://github.com/user-attachments/assets/d2e71a33-3ece-4e39-81c5-7de3f4832a3f)
- 3 POST http://localhost:8080/api/student/submits
    - 새로운 제출 내역 제출 (파일이 0~n개 제출 가능) api 요청 시 상세 내용은 swagger를 참고해주세요 (ex, request body -> form-data)

- 이외의 제출내역 삭제 기능이 있습니다.
