### PR TITLE
[Feat] 제출 방식 변경

### DIFF
--- a/src/main/db/init.sql
+++ b/src/main/db/init.sql
@@ -154,7 +154,7 @@ CREATE TABLE comment (
     submit_id   BIGINT NOT NULL,
     comment_content TEXT,
     comment_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    comment_state INT DEFAULT 0, -- 0 : 미승인, 1 : 승인, 2 : 거부
+#     comment_state INT DEFAULT 0, -- 0 : 미승인, 1 : 승인, 2 : 거부
 
     CONSTRAINT fk_comment_submit
         FOREIGN KEY (submit_id)

--- a/src/main/java/com/skku/sucpi/controller/admin/AdminController.java
+++ b/src/main/java/com/skku/sucpi/controller/admin/AdminController.java
@@ -5,8 +5,10 @@ import com.skku.sucpi.dto.PaginationDto;
 import com.skku.sucpi.dto.activity.ActivityDto;
 import com.skku.sucpi.dto.activity.ActivityStatsDto;
 import com.skku.sucpi.dto.category.RatioResponseDto;
+import com.skku.sucpi.dto.comment.CommentUpdateDto;
 import com.skku.sucpi.dto.score.ScoreAverageDto;
 import com.skku.sucpi.dto.score.ScoreDepartmentAverageDto;
+import com.skku.sucpi.dto.submit.SubmitCommentDto;
 import com.skku.sucpi.dto.submit.SubmitCountDto;
 import com.skku.sucpi.dto.submit.SubmitDto;
 import com.skku.sucpi.dto.submit.SubmitStateDto;
@@ -231,11 +233,10 @@ public class AdminController {
 
     @PostMapping("/submit/state")
     @Operation(
-            summary = "제출 승인/거부 api",
+            summary = "제출 상태 변경",
             description = """
                     **설명**
-                    - 제출 내역을 승인 또는 반려하는 API
-                    - 반려 시, 반려 사유를 함께 전달
+                    - 제출 내역 상태를 변경하는 API
 
                     **사용법**
                     - Method : POST
@@ -246,8 +247,7 @@ public class AdminController {
 
                     **Request Body**
                     - id (Long, required) : 제출 내역의 고유 아이디
-                    - state (Integer, required) : 0=미승인, 1=승인, 2=반려
-                    - comment (String, not required) : 사유
+                    - state (Integer, required) : 0=미승인(대기), 1=승인, 2=반려
                     """
     )
     public ApiResponse<SubmitStateDto.Response> updateSubmitState(
@@ -255,6 +255,117 @@ public class AdminController {
             HttpServletRequest r
             ) {
         return ApiResponse.success(submitService.updateSubmitState(request), r.getRequestURI());
+    }
+
+    @DeleteMapping("/submit/{id}")
+    @Operation(
+            summary = "제출 내역 삭제",
+            description = """
+                    **설명**
+                    - 제출 내역을 삭제하는 API
+                    
+                    **사용법**
+                    - Method : DELETE
+                    - Path : /api/admin/submit/{id}
+                    
+                    **헤더**
+                    - Authorization: Bearer {accessToken}
+                    
+                    **Path Variable**
+                    - id (Long, required) : 제출 내역의 고유 아이디
+                    """
+    )
+    public ApiResponse<Void> deleteSubmit(
+            @PathVariable Long id,
+            HttpServletRequest r
+    ) {
+        submitService.deleteSubmitForAdmin(id);
+        return ApiResponse.success(null, r.getRequestURI());
+    }
+
+
+
+    @PostMapping("/submit/comment")
+    @Operation(
+            summary = "제출 내역 댓글 작성",
+            description = """
+                    **설명**
+                    - 제출 내역 상태를 변경하는 API
+
+                    **사용법**
+                    - Method : POST
+                    - Path : /api/admin/submit/state
+
+                    **헤더**
+                    - Authorization: Bearer {accessToken}
+
+                    **Request Body**
+                    - id (Long, required) : 제출 내역의 고유 아이디
+                    - comment (String, required) : 댓글 내용
+                    """
+    )
+    public ApiResponse<SubmitCommentDto.Response> updateSubmitComment(
+            @RequestBody SubmitCommentDto.Request request,
+            HttpServletRequest r
+    ) {
+        return ApiResponse.success(submitService.createSubmitComment(request), r.getRequestURI());
+    }
+
+
+
+    @PatchMapping("/submit/comment")
+    @Operation(
+            summary = "제출 내역 댓글 수정",
+            description = """
+                    **설명**
+                    - 제출 내역 댓글을 수정하는 API
+                    
+                    **사용법**
+                    - Method : PATCH
+                    - Path : /api/admin/submit/comment/{id}
+                    
+                    **헤더**
+                    - Authorization: Bearer {accessToken}
+                    
+                    **Request Body**
+                    - id (Long, required) : 댓글의 고유 아이디
+                    - content (String, required) : 댓글 내용
+                    """
+    )
+    public ApiResponse<CommentUpdateDto.Response> updateSubmitComment(
+            @RequestBody CommentUpdateDto.Request request,
+            HttpServletRequest r
+    ) {
+        return ApiResponse.success(submitService.updateSubmitComment(request), r.getRequestURI());
+    }
+
+
+
+    @DeleteMapping("/submit/comment/{id}")
+    @Operation(
+            summary = "제출 내역 댓글 삭제",
+            description = """
+                    **설명**
+                    - 제출 내역 댓글을 삭제하는 API
+                    
+                    **사용법**
+                    - Method : DELETE
+                    - Path : /api/admin/submit/comment/{id}
+                    
+                    **헤더**
+                    - Authorization: Bearer {accessToken}
+                    
+                    **Path Variable**
+                    - id (Long, required) : 댓글의 고유 아이디
+                    """
+    )
+    public ApiResponse<Void> deleteSubmitComment(
+            @PathVariable Long id,
+            HttpServletRequest r
+    ) {
+        submitService.deleteSubmitComment(id);
+
+        return ApiResponse.success(null, r.getRequestURI());
     }
 
 

--- a/src/main/java/com/skku/sucpi/controller/student/StudentController.java
+++ b/src/main/java/com/skku/sucpi/controller/student/StudentController.java
@@ -6,6 +6,7 @@ import java.util.StringTokenizer;
 import com.skku.sucpi.dto.score.MonthlyScoreDto;
 import com.skku.sucpi.dto.score.StudentScoreAverageDto;
 import com.skku.sucpi.dto.score.StudentScoreDto;
+import com.skku.sucpi.dto.submit.SubmitUpdateRequestDto;
 import com.skku.sucpi.service.fileStorage.FileStorageService;
 import com.skku.sucpi.service.score.ScoreService;
 import com.skku.sucpi.service.score.ScoreSubmitService;
@@ -16,15 +17,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.skku.sucpi.dto.ApiResponse;
@@ -250,6 +243,40 @@ public class StudentController {
         return ApiResponse.success(submitService.createSubmit(userId, dto), request.getRequestURI());
     }
 
+    @PatchMapping(value = "/submits/{id}")
+    @Operation(
+            summary = "내 활동 제출 수정",
+            description = """
+                **설명**
+                - 학생이 본인의 활동 제출을 수정하는 API
+                - 승인된 제출은 수정할 수 없음
+               
+                **사용법**
+                - Method : PATCH
+                - Path : /api/student/submits/{id}
+                - Body : JSON
+                
+                **헤더**
+                - Authorization: Bearer {accessToken}
+                
+                **Path Variable**
+                - id : 제출 내역 ID
+                
+                **Request Body**
+                - title: String (nullable, 활동 제목)
+                - content: String (nullable, 활동 내용)
+                """
+    )
+    public ApiResponse<SubmitDto.BasicInfo> updateSubmit(
+            @PathVariable Long id,
+            @RequestBody SubmitUpdateRequestDto dto,
+            HttpServletRequest request
+    ) {
+        String token = jwtUtil.parseJWT(request);
+        Long userId = jwtUtil.getUserId(token);
+
+        return ApiResponse.success(submitService.updateSubmit(userId, id, dto), request.getRequestURI());
+    }
 
 
     @PostMapping(value="/submits/{id}/file", consumes=MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/skku/sucpi/dto/comment/CommentDto.java
+++ b/src/main/java/com/skku/sucpi/dto/comment/CommentDto.java
@@ -16,7 +16,6 @@ public class CommentDto {
     static public class BasicInfo {
         private Long id;
         private String content;
-        private Integer state;
         private LocalDateTime date;
     }
 
@@ -33,7 +32,6 @@ public class CommentDto {
         return BasicInfo.builder()
                 .id(comment.getId())
                 .content(comment.getContent())
-                .state(comment.getState())
                 .date(comment.getDate())
                 .build();
     }

--- a/src/main/java/com/skku/sucpi/dto/comment/CommentUpdateDto.java
+++ b/src/main/java/com/skku/sucpi/dto/comment/CommentUpdateDto.java
@@ -1,28 +1,27 @@
-package com.skku.sucpi.dto.submit;
+package com.skku.sucpi.dto.comment;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.extern.jackson.Jacksonized;
 
-public class SubmitStateDto {
+public class CommentUpdateDto {
 
     @Getter
     @Setter
     @NoArgsConstructor
-    @Schema (name = "SubmitStateDto_Request")
+    @Schema (name = "CommentUpdateDto_Request")
     static public class Request {
         private Long id;
-        private Integer state; // 0: 미승인, 1: 승인, 2: 거부
+        private String content;
     }
 
     @Getter
     @Builder
-    @Schema (name = "SubmitStateDto_Response")
+    @Schema (name = "CommentUpdateDto_Response")
     static public class Response {
         private Long id;
-        private Integer state; // 0: 미승인, 1: 승인, 2: 거부
+        private String content;
     }
 }

--- a/src/main/java/com/skku/sucpi/dto/submit/SubmitCommentDto.java
+++ b/src/main/java/com/skku/sucpi/dto/submit/SubmitCommentDto.java
@@ -5,24 +5,23 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.extern.jackson.Jacksonized;
 
-public class SubmitStateDto {
+public class SubmitCommentDto {
 
     @Getter
     @Setter
     @NoArgsConstructor
-    @Schema (name = "SubmitStateDto_Request")
+    @Schema (name = "SubmitCommentDto_Request")
     static public class Request {
         private Long id;
-        private Integer state; // 0: 미승인, 1: 승인, 2: 거부
+        private String content;
     }
 
     @Getter
     @Builder
-    @Schema (name = "SubmitStateDto_Response")
+    @Schema (name = "SubmitCommentDto_Response")
     static public class Response {
         private Long id;
-        private Integer state; // 0: 미승인, 1: 승인, 2: 거부
+        private String content;
     }
 }

--- a/src/main/java/com/skku/sucpi/dto/submit/SubmitUpdateRequestDto.java
+++ b/src/main/java/com/skku/sucpi/dto/submit/SubmitUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package com.skku.sucpi.dto.submit;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SubmitUpdateRequestDto {
+
+    private String title;
+
+    private String content;
+}

--- a/src/main/java/com/skku/sucpi/entity/Comment.java
+++ b/src/main/java/com/skku/sucpi/entity/Comment.java
@@ -28,10 +28,11 @@ public class Comment {
     @UpdateTimestamp
     private LocalDateTime date;
 
-    @Column(name = "comment_state")
-    private Integer state; // 0: 미확인(미승인), 1: 확인(승인), 2: 반려
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "submit_id", nullable = false)
     private Submit submit;
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/skku/sucpi/entity/Submit.java
+++ b/src/main/java/com/skku/sucpi/entity/Submit.java
@@ -64,7 +64,6 @@ public class Submit {
 
     public void updateState(Integer state) {
         this.state = state;
-        this.approvedDate = LocalDateTime.now();
     }
 
     public void updateComment(String comment) {

--- a/src/main/java/com/skku/sucpi/entity/Submit.java
+++ b/src/main/java/com/skku/sucpi/entity/Submit.java
@@ -70,4 +70,12 @@ public class Submit {
     public void updateComment(String comment) {
 //        this.comment = comment;
     }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/skku/sucpi/service/submit/SubmitService.java
+++ b/src/main/java/com/skku/sucpi/service/submit/SubmitService.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import com.skku.sucpi.dto.activity.ActivityStatsDto;
 import com.skku.sucpi.dto.comment.CommentDto;
-import com.skku.sucpi.dto.submit.SubmitCountDto;
+import com.skku.sucpi.dto.submit.*;
 import com.skku.sucpi.entity.*;
 import com.skku.sucpi.repository.*;
 import org.springframework.data.domain.Pageable;
@@ -15,9 +15,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.skku.sucpi.dto.PaginationDto;
 import com.skku.sucpi.dto.fileStorage.FileInfoDto;
-import com.skku.sucpi.dto.submit.SubmitCreateRequestDto;
-import com.skku.sucpi.dto.submit.SubmitDto;
-import com.skku.sucpi.dto.submit.SubmitStateDto;
 import com.skku.sucpi.service.category.CategoryService;
 import com.skku.sucpi.service.fileStorage.FileStorageService;
 import com.skku.sucpi.service.score.ScoreService;
@@ -178,6 +175,38 @@ public class SubmitService {
         Submit saved = submitRepository.save(submit);
 
         return SubmitDto.from(saved);
+    }
+
+    @Transactional
+    public SubmitDto.BasicInfo updateSubmit(
+            Long userId,
+            Long submitId,
+            SubmitUpdateRequestDto dto
+    ) {
+        Submit submit = submitRepository.findById(submitId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 제출 내역입니다."));
+
+        // 1) 본인 소유 확인
+        if (!submit.getUser().getId().equals(userId)) {
+            throw new IllegalArgumentException("본인의 제출만 수정할 수 있습니다.");
+        }
+
+        // 2) 승인된 제출은 수정 불가
+        if (submit.getState() == 1) {
+            throw new IllegalArgumentException("승인된 제출은 수정할 수 없습니다.");
+        }
+
+        // 3) 수정, 상태를 미승인(0)으로 변경
+        if (dto.getTitle() != null && !dto.getTitle().isEmpty()) {
+            submit.updateTitle(dto.getTitle());
+        }
+        if (dto.getContent() != null && !dto.getContent().isEmpty()) {
+            submit.updateContent(dto.getContent());
+        }
+        submit.updateState(0);
+
+
+        return SubmitDto.from(submit);
     }
 
 

--- a/src/main/java/com/skku/sucpi/service/submit/SubmitService.java
+++ b/src/main/java/com/skku/sucpi/service/submit/SubmitService.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.skku.sucpi.dto.activity.ActivityStatsDto;
 import com.skku.sucpi.dto.comment.CommentDto;
+import com.skku.sucpi.dto.comment.CommentUpdateDto;
 import com.skku.sucpi.dto.submit.*;
 import com.skku.sucpi.entity.*;
 import com.skku.sucpi.repository.*;
@@ -60,39 +61,88 @@ public class SubmitService {
         Long categoryId = activity.getCategory().getId();
         Double diff = activity.getWeight();
 
-        // 1. 미승인, 거부 -> 승인
+        updateCategoryScore(curState, state, categoryId, diff, isYuljeon, submit);
+
+        submit.updateState(request.getState());
+
+        return SubmitStateDto.Response.builder()
+                .id(submit.getId())
+                .state(submit.getState())
+                .build();
+    }
+
+    public void deleteSubmitForAdmin(Long submitId) {
+        Submit submit = submitRepository.findById(submitId)
+                .orElseThrow(() -> new IllegalArgumentException("No submit id : " + submitId));
+
+        Integer state = 2; // 반려 상태로 변경
+        Integer curState = submit.getState();
+        boolean isYuljeon = UserUtil.checkCampusY(submit.getUser().getHakgwaCd());
+        Activity activity = submit.getActivity();
+        Long categoryId = activity.getCategory().getId();
+        Double diff = activity.getWeight();
+
+        updateCategoryScore(curState, state, categoryId, diff, isYuljeon, submit);
+
+        submitRepository.delete(submit);
+    }
+
+
+    public SubmitCommentDto.Response createSubmitComment(SubmitCommentDto.Request request) {
+        Submit submit = submitRepository.findById(request.getId())
+                .orElseThrow(() -> new IllegalArgumentException("No submit id : " + request.getId()));
+
+        Comment comment = Comment.builder()
+                .submit(submit)
+                .content(request.getContent())
+                .build();
+
+        commentRepository.save(comment);
+
+        return SubmitCommentDto.Response.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .build();
+    }
+
+    public CommentUpdateDto.Response updateSubmitComment(CommentUpdateDto.Request request) {
+        Comment comment = commentRepository.findById(request.getId())
+                .orElseThrow(() -> new IllegalArgumentException("No comment id : " + request.getId()));
+
+        comment.updateContent(request.getContent());
+
+        return CommentUpdateDto.Response.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .build();
+    }
+
+    public void deleteSubmitComment(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("No comment id : " + commentId));
+        commentRepository.delete(comment);
+    }
+
+
+    private void updateCategoryScore(Integer curState, Integer state, Long categoryId, Double diff, boolean isYuljeon, Submit submit) {
+        // 1. 미승인, 반려 -> 승인
         if ((curState == 0 || curState == 2) && state == 1) {
             // 카테고리 점수 수정
             categoryService.updateSumAndSquareSum(categoryId, diff, isYuljeon);
 
             // 학생 점수 수정
-            scoreService.updateScore(submit.getUser().getId() ,categoryId, diff);
+            scoreService.updateScore(submit.getUser().getId() , categoryId, diff);
         }
-        // 2. 승인 -> 거절
-        else if ((curState == 1) && state == 2) {
+        // 2. 승인 -> 미승인, 반려
+        else if ((curState == 1) && (state == 0 || state == 2)) {
             diff *= -1;
 
             // 카테고리 점수 수정
             categoryService.updateSumAndSquareSum(categoryId, diff, isYuljeon);
 
             // 학생 점수 수정
-            scoreService.updateScore(submit.getUser().getId() ,categoryId, diff);
+            scoreService.updateScore(submit.getUser().getId() , categoryId, diff);
         }
-
-        submit.updateComment(request.getComment());
-        submit.updateState(request.getState());
-        commentRepository.save(Comment.builder().
-                content(request.getComment()).
-                state(request.getState()).
-                submit(submit).
-                build());
-
-        return SubmitStateDto.Response.builder()
-                .id(submit.getId())
-                .state(submit.getState())
-                .comment(request.getComment())
-                .build();
-
     }
 
     public List<Submit> getSubmitListByUserId(Long userId) {


### PR DESCRIPTION
## 학생 제출 방식 변경
1. 학생은 활동을 제출할 때 제목을 작성해야 합니다.
2. 학생은 제출한 활동 내역을 수정 / 삭제할 수 있어야 합니다. 수정할 시 자동으로 '대기(미승인)' 상태로 변경됩니다.
3. 학생은 관리자가 작성한 사유(댓글) 목록을 확인할 수 있습니다.

## 관리자 승인 방식 변경
1. 관리자는 작성한 사유(댓글) 목록을 확인할 수 있습니다.
2. 승인, 반려된 제출 내역도 수정 가능합니다.
3. 제출 내역을 삭제할 수 있습니다.